### PR TITLE
Enable JMX server for monitoring

### DIFF
--- a/manifests/tomcat-application.pp
+++ b/manifests/tomcat-application.pp
@@ -6,7 +6,9 @@ define tomcat7_rhel::tomcat-application(
   $jvm_envs,
   $tomcat_manager = false,
   $tomcat_admin_user = "tomcat",
-  $tomcat_admin_password = "s3cr3t") {
+  $tomcat_admin_password = "s3cr3t",
+  $jmxRegistryPort = 10052,
+  $jmxServerPort = 10051) {
   include tomcat7_rhel
 
   $application_dir = "$application_root/$application_name"

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -31,6 +31,7 @@
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.JmxRemoteLifecycleListener" rmiRegistryPortPlatform="<%=jmxRegistryPort%>" rmiServerPortPlatform="<%=jmxServerPort %>" />
 
   <!-- Global JNDI resources
        Documentation at /docs/jndi-resources-howto.html


### PR DESCRIPTION
Binds to ports 10052 & 10051, so server can be monitored by tools like jconsole or visualvm by connecting to port 10052.
