### PR TITLE
Some improvements to logging

### DIFF
--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -134,6 +134,7 @@
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b %T %{User-Agent}i" 
+	       rotatable=false/>
       </Host>
     </Engine>
   </Service>

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -134,7 +134,7 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log." suffix=".txt"
+               prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b %T %{User-Agent}i" 
 	       rotatable="false"/>
       </Host>

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -136,7 +136,7 @@
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b %T %{User-Agent}i" 
-	       rotatable=false/>
+	       rotatable="false"/>
       </Host>
     </Engine>
   </Service>

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -129,8 +129,10 @@
         <!--
         <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
         -->
+	<!-- Remote IP Valve: X-forwarded-for -> request.address-->
+	<Valve className="org.apache.catalina.valves.RemoteIpValve" />
         <!-- Access log processes all example.
-             Documentation at: /docs/config/valve.html
+             Documentation at: /docs/config/valve.html -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b %T %{User-Agent}i" 

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -129,14 +129,11 @@
         <!--
         <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
         -->
-
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
-             Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
-
+               pattern="%h %l %u %t &quot;%r&quot; %s %b %T %{User-Agent}i" 
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
1) Show useragent & request time in access logs
2) Fixed bug where both logrotate & tomcat were rotating logs, creating thousands of empty log files
3) Add RemoteIpValve so container sees users actual IP, and not IP of LB/Reverse proxy. Basically it makes IP from X-Forwarded-For header to be request.address, which is useful as I believe most Tomcat installations are behind reverse proxy. If no X-Forwarded-For header is given, it works as previously.
