### PR TITLE
Add possibility to define path for smoketest

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Features
         tomcat_manager => true,
         tomcat_admin_user => "superuser",
         tomcat_admin_password => "secretpassword",
+        smoke_test_path => "/health-check"
         jmx_registry_port => 10054,
         jmx_server_port => 10053
       }

--- a/manifests/tomcat_application.pp
+++ b/manifests/tomcat_application.pp
@@ -10,7 +10,8 @@ define tomcat7_rhel::tomcat_application(
   $tomcat_admin_password = "s3cr3t",
   $server_xml_engine_config = "",
   $jmx_registry_port = 10052,
-  $jmx_server_port = 10051) {
+  $jmx_server_port = 10051,
+  $smoke_test_path = "/") {
   include tomcat7_rhel
 
   $application_dir = "$application_root/$application_name"

--- a/spec/defines/tomcat7_rhel__tomcat_application_spec.rb
+++ b/spec/defines/tomcat7_rhel__tomcat_application_spec.rb
@@ -169,11 +169,11 @@ describe 'tomcat7_rhel::tomcat_application' do
 
     it {
       should contain_file('/opt/my-web-app/bin/run_smoke_test.sh').
-        with_content(/.*curl -L.*localhost:8123.*/m)
+        with_content(/.*curl --fail --retry 3 -L.*localhost:8123\/.*/m)
     }
   end
 
-  describe 'Specifying additional engine XML config' do
+    describe 'Specifying additional engine XML config' do
     let(:title) { 'my-web-app' }
 
     let(:params) {{
@@ -187,6 +187,23 @@ describe 'tomcat7_rhel::tomcat_application' do
     it {
       should contain_file('/opt/my-web-app/conf/server.xml').
       with_content(/.*<Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"\/>.*/m)
+    }
+  end
+
+  describe 'Specifying healthcheck url for smoketest' do
+    let(:title) { 'my-web-app' }
+
+    let(:params) {{
+      :application_root         => '/opt',
+      :tomcat_user              => 'uzer',
+      :tomcat_port              => 8123,
+      :jvm_envs                 => '-Di_love_java=true',
+      :smoke_test_path => "/health"
+    }}
+
+    it {
+      should contain_file('/opt/my-web-app/bin/run_smoke_test.sh').
+        with_content(/.*curl --fail --retry 3 -L.*localhost:8123\/health.*/m)
     }
   end
 

--- a/templates/run_smoke_test.sh.erb
+++ b/templates/run_smoke_test.sh.erb
@@ -1,20 +1,10 @@
 #!/bin/bash
 
-COUNTER=0
-while curl -L -s -o /dev/null -w "%{http_code}" localhost:<%=tomcat_port%> | grep -v 200; do
-  echo Waiting for <%=application_name%> to respond...
-  let COUNTER=COUNTER+1
-  if [  $COUNTER -ge 40 ]; then
-    break
-  fi
-  sleep 2
-done
-
-curl --fail -L -s -o /dev/null -w "%{http_code}" localhost:<%=tomcat_port%> | grep 200 > /dev/null
+curl --fail --retry 3 -L -sS -o /dev/null -w "%{http_code}" localhost:<%=tomcat_port%><%=smoke_test_path%> | grep 200 > /dev/null
 if [[ "$?" -eq 0 ]]; then
-  echo "Smoke test on <%=application_name%> succeeded"
+  echo "Smoke test on <%=application_name%> Succeeded"
   exit 0
 else
-  echo "Smoke test on <%=application_name%> failed"
+  echo "Smoke test on <%=application_name%> FAILED!"
   exit 1
 fi


### PR DESCRIPTION
HealthCheck url is useful eg. when your application has backend and you want to make sure that connection from your webapp to that backend works.

Previously tomcat7_rhel expected this health check url to be "/", this pull request will make it configurable, with default value of "/".

This pull request will also make smoketest script to fail fast in case health check url is not responding with http 200.
