### PR TITLE
Allow java to be installed by other modules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,17 +2,21 @@ class tomcat7_rhel ( $manage_java = true ){
   include tomcat7_rhel::jpackage_repo
 
   if $manage_java {
-    package { "java-1.7.0-openjdk":
-      ensure => latest
+    package { 'java-1.7.0-openjdk':
+      ensure => latest,
     }
-    package { "java-1.7.0-openjdk-devel":
+    package { 'java-1.7.0-openjdk-devel':
       ensure  => latest,
-      require => Package["java-1.7.0-openjdk"]
+      require => Package['java-1.7.0-openjdk'],
+    }
+    package { 'tomcat7':
+      ensure  => installed,
+      require => [Package['java-1.7.0-openjdk'], Yumrepo['jpackage']],
+    }
+  } else {
+    package { 'tomcat7':
+      ensure => installed,
     }
   }
 
-  package { "tomcat7":
-    ensure => installed,
-    require => [Package['java-1.7.0-openjdk'], Yumrepo['jpackage']]
-  }
 }

--- a/manifests/tomcat_instances.pp
+++ b/manifests/tomcat_instances.pp
@@ -1,0 +1,6 @@
+class tomcat7_rhel::tomcat_instances (
+  $instances = {}
+) {
+  create_resources('tomcat7_rhel::tomcat_application', $instances)
+}
+

--- a/templates/etc/sysconfig/tomcat7.erb
+++ b/templates/etc/sysconfig/tomcat7.erb
@@ -5,7 +5,7 @@ CATALINA_TMPDIR="$CATALINA_BASE/temp"
 
 JVM_OPTS="<%= jvm_envs %>"
 
-JAVA_OPTS="${JAVA_OPTS}"
+JAVA_OPTS="${JVM_OPTS}"
 
 # What user should run tomcat
 TOMCAT_USER="<%= tomcat_user %>"

--- a/templates/etc/sysconfig/tomcat7.erb
+++ b/templates/etc/sysconfig/tomcat7.erb
@@ -5,7 +5,7 @@ CATALINA_TMPDIR="$CATALINA_BASE/temp"
 
 JVM_OPTS="<%= jvm_envs %>"
 
-JAVA_OPTS="${JAVA_OPTS} ${JVM_OPTS}"
+JAVA_OPTS="${JAVA_OPTS}"
 
 # What user should run tomcat
 TOMCAT_USER="<%= tomcat_user %>"


### PR DESCRIPTION
There are modules which do the java installation separately. Also some organisations like us define all packages in a custom module as a virtual resource.
