### PR TITLE
Added support for configuring the managers allow/deny IP's.

### DIFF
--- a/manifests/tomcat_application.pp
+++ b/manifests/tomcat_application.pp
@@ -8,6 +8,8 @@ define tomcat7_rhel::tomcat_application(
   $tomcat_manager = false,
   $tomcat_admin_user = "tomcat",
   $tomcat_admin_password = "s3cr3t",
+  $tomcat_manager_allow_ip = "127\.0\.0\.1|0:0:0:0:0:0:0:1",
+  $tomcat_manager_deny_ip = "",
   $server_xml_engine_config = "",
   $disable_access_log = false,
   $jmx_registry_port = 10052,
@@ -54,6 +56,8 @@ define tomcat7_rhel::tomcat_application(
     tomcat7_rhel::tomcat_manager { "Install Tomcat Manager for $application_name":
     tomcat_admin_user => $tomcat_admin_user,
     tomcat_admin_password => $tomcat_admin_password,
+    tomcat_manager_allow_ip => $tomcat_manager_allow_ip,
+    tomcat_manager_deny_ip => $tomcat_manager_deny_ip,
     tomcat_user => $tomcat_user,
     application_dir => $application_dir,
     application_name => $application_name,

--- a/manifests/tomcat_manager.pp
+++ b/manifests/tomcat_manager.pp
@@ -1,6 +1,8 @@
 define tomcat7_rhel::tomcat_manager(
                                     $tomcat_admin_user,
                                     $tomcat_admin_password,
+                                    $tomcat_manager_allow_ip,
+                                    $tomcat_manager_deny_ip,
                                     $tomcat_user,
                                     $application_dir,
                                     $application_name,

--- a/spec/defines/tomcat7_rhel__tomcat_application_spec.rb
+++ b/spec/defines/tomcat7_rhel__tomcat_application_spec.rb
@@ -9,6 +9,7 @@ describe 'tomcat7_rhel::tomcat_application' do
       :tomcat_user      => 'uzer',
       :tomcat_port      => 8123,
       :tomcat_manager   => true,
+      :tomcat_manager_allow_ip => '192\.168\..*',
       :jvm_envs         => '-Di_love_tomcat=true'
     }}
 
@@ -25,7 +26,8 @@ describe 'tomcat7_rhel::tomcat_application' do
     it {
       should contain_file(
         '/opt/my-app-with-tomcat-manager/conf/Catalina/localhost/manager.xml').
-        with_content(/.*Context path="\/manager".*/m)
+        with_content(/.*Context path="\/manager".*/m).
+        with_content(/.*allow="192\\.168\\.\.\*".*/m)
     }
 
     it {

--- a/templates/manager.xml.erb
+++ b/templates/manager.xml.erb
@@ -1,4 +1,4 @@
 <!--<?xml version="1.0" encoding="UTF-8"?> -->
 <Context path="/manager" docBase="/var/lib/tomcat7/webapps/manager" antiResourceLocking="false" privileged="true">
- 	<Valve className="org.apache.catalina.valves.RemoteAddrValve" allow="127\.0\.0\.1|0:0:0:0:0:0:0:1" deny="" />
+  <Valve className="org.apache.catalina.valves.RemoteAddrValve" allow="<%= @tomcat_manager_allow_ip %>" deny="<%= @tomcat_manager_deny_ip %>" />
 </Context>


### PR DESCRIPTION
Added support for configuring manager allow/deny ip. Default behaviour is as before _allow:_  `"127\.0\.0\.1|0:0:0:0:0:0:0:1"` and _deny:_ `""`.
